### PR TITLE
Add guard to skip release workflow for version tag commits

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   publish:
+    if: ${{ !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'v')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add a conditional to the publish job so version-tag pushes do not trigger the release workflow

## Testing
- bunx tsc --noEmit
- bun run format *(fails: Script not found "format")*


------
https://chatgpt.com/codex/tasks/task_b_68e5dc629468832e9c1b74f21128b120