### PR TITLE
Migrate npm publishing workflows and template to OIDC

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -16,15 +22,15 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: pver release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
       # - name: Trigger workflow dispatch in @tscircuit/eval repo
       #   run: |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "tscircuit-plop": "./index.js",
     "plop": "./index.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tscircuit/plop"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/template-files/bun-pver-release.yml
+++ b/template-files/bun-pver-release.yml
@@ -7,6 +7,11 @@ on:
       - '!version-bumps/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
   UPSTREAM_REPOS: "" # comma-separated list, e.g. "eval,tscircuit,docs"
   UPSTREAM_PACKAGES_TO_UPDATE: "" # comma-separated list, e.g. "@tscircuit/core,@tscircuit/protos"
@@ -20,16 +25,16 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
       - run: npm install -g pver
       - run: bun install --frozen-lockfile
       - run: bun run build
       - run: pver release --no-push-main
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.TSCIRCUIT_BOT_GITHUB_TOKEN }}
 
       - name: Get package version


### PR DESCRIPTION
## Summary

- migrate the repository npm publishing workflow to npm trusted publishing via OIDC
- update the reusable `bun-pver-release.yml` template to the same configuration
- add the required `permissions` for package publishing and release automation
- add the package `repository` metadata required to match `tscircuit/plop` for npm trusted publishing
- update `actions/setup-node` to v6 and Node.js to 24
- disable package-manager caching and remove the legacy `NPM_TOKEN` configuration

## Why

Aligns this repository and its generated workflow template with the OIDC npm publishing migration from [circuit-json-to-kicad PR #418](https://github.com/tscircuit/circuit-json-to-kicad/pull/418). npm validates the package repository against the configured GitHub trusted publisher.

## Validation

- `git diff --check`
- `node --check index.js`
- verified `package.json.repository.url` is `https://github.com/tscircuit/plop`
- reviewed the resulting workflow and template diff